### PR TITLE
Enabling packrat parsing in ptxparser.py

### DIFF
--- a/ptxparser.py
+++ b/ptxparser.py
@@ -1,5 +1,5 @@
 from pyparsing import *
-
+ParserElement.enable_packrat()
 
 
 # 4.4. Identifiers
@@ -56,7 +56,7 @@ PARAM = Group(
     Suppress(".param") + TYPE + Optional(Literal(".ptr") + Optional(SPACE) + ALIGN)
     + TYPENAME
 )
-ARGLIST = Group(DelimitedList(PARAM))
+ARGLIST = Group(delimitedList(PARAM))
 
 KERNELDEF = (
     Literal(".entry") + IDENTIFIER + Suppress("(") + ARGLIST + Suppress(")")
@@ -144,8 +144,8 @@ INSTRUCTION = Group(
     Combine(IDENTIFIER + Literal(":")) ^
     (
         Optional(Literal("@") + Optional("!") + REGISTER_LIKE) + 
-        DelimitedList(IDENTIFIER, ".", True, min=1) +
-        Optional(Group(DelimitedList(INSTR_OPERAND))) +
+        delimitedList(IDENTIFIER, ".", True, min=1) +
+        Optional(Group(delimitedList(INSTR_OPERAND))) +
         Suppress(";")
     )
 )


### PR DESCRIPTION
Credit to @ken__maples on twitter. Link to discussion: https://twitter.com/Sheikheddy/status/1671513229686702080

This PR enables packrat parsing in ptxparser.py, which improves kernel parsing performance. The change was tested once on a single input file in Python 3.10 and was found to improve parsing performance from 30160 to 683 ms. 

Changed Group(DelimitedList) to Group(delimitedList) to avoid NameError issues.